### PR TITLE
feat: add beforeScan hook

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -41,11 +41,16 @@ async function run({
     importedFrom,
     getComponentName,
     getPropValue,
+    beforeScan,
   } = config;
 
   for (let i = 0, len = files.length; i < len; i++) {
     const filePath = files[i];
-    const code = fs.readFileSync(filePath, "utf8");
+    let code = fs.readFileSync(filePath, "utf8");
+
+    if (beforeScan) {
+      code = beforeScan(code);
+    }
 
     scan({
       code,

--- a/test/configs/noProcessors.config.js
+++ b/test/configs/noProcessors.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   crawlFrom: "../code",
+  beforeScan: function (code) {
+    return code;
+  },
 };


### PR DESCRIPTION
Allows to for example manually replace out some parts in the source code that cause errors (but actually run fine) in AST parsing.